### PR TITLE
CI: Deploy website to Netlify

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Netlify Status](https://api.netlify.com/api/v1/badges/2235e531-ad29-4b4a-b306-9b9b9d3bac17/deploy-status)](https://app.netlify.com/sites/vig/deploys)
+
 # Vigor-App
 
 This repo manages the standalone React frontend for the Vigor stablecoin app.

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,6 @@
+[build]
+  command = "yarn build"
+  publish = "build"
+
+[context.production.environment]
+  REACT_APP_SOME_VAR = "From netlify.toml (REACT_APP_)"


### PR DESCRIPTION
## Changelog

* Add deploy to Netlify (fixes #6 for now)

## Remarks

Could not also add a deploy to github-pages because I can only deploy the `master` branch:
> If your site is a User or Organization Page that has a repository named <username>.github.ioor <orgname>.github.io, you cannot publish your site's source files from different locations. User and Organization Pages that have this type of repository name are only published from the master branch. - https://help.github.com/en/articles/configuring-a-publishing-source-for-github-pages

Might want to change this in the future